### PR TITLE
Create index on external_fid if it is created

### DIFF
--- a/optimizer.go
+++ b/optimizer.go
@@ -65,6 +65,7 @@ func optimizeOAFGeopackage(sourceGeopackage string, config string) {
 			if layerCfg.ExternalFidColumns != nil {
 				addColumn(tableName, "external_fid", "TEXT", db)
 				setColumnValue(tableName, "external_fid", fmt.Sprintf("uuid5('%s', '%s'||%s)", pdokNamespace, tableName, strings.Join(layerCfg.ExternalFidColumns, "||")), db)
+				createIndex(tableName, []string{"external_fid"}, fmt.Sprintf("%s_external_fid_idx", tableName), false, db)
 			}
 
 			if layerCfg.TemporalColumns != nil {


### PR DESCRIPTION
# Description

When an `external_fid` column is created for a layer, create an index on the `external_fid` column as well.

## Type of change

(Remove irrelevant options)

- Improvement of existing feature

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [x] The code is readable, comments are added that explain hard or non-obvious parts.
- [x] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [x] There's no sensitive information like credentials in my PR