### PR TITLE
Add support for relations between OGC API Features (part 5) - support composite keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,6 @@ docker run -v `pwd`/geopackage:/geopackage pdok/geopackage-optimizer-go
     -service-type oaf 
     -config '{"layers":{"mytable":{"external-fid-columns":["fid"]}}}'
 ```
+
+Optionally, one can add relations between features using this tool. 
+This is in support of [OAF Part 5 Feature References](https://docs.ogc.org/DRAFTS/23-058r1.html#rc_profile-references).

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.23
 require (
 	github.com/creasty/defaults v1.8.0
 	github.com/google/uuid v1.6.0
-	github.com/mattn/go-sqlite3 v1.14.24
+	github.com/mattn/go-sqlite3 v1.14.28
 )

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
 github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
+github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/oaf_config.go
+++ b/oaf_config.go
@@ -29,9 +29,8 @@ type Relation struct {
 }
 
 type RelationColumns struct {
-	ForeignKey string `json:"fk"`
-	PrimaryKey string `json:"pk"`
-	Prefix     string `json:"prefix"`
+	Keys   []RelationKey `json:"keys"`
+	Prefix string        `json:"prefix"`
 }
 
 func (r *Relation) ColumnName() string {
@@ -41,4 +40,9 @@ func (r *Relation) ColumnName() string {
 	}
 	result += "_external_fid"
 	return result
+}
+
+type RelationKey struct {
+	ForeignKey string `json:"fk"`
+	PrimaryKey string `json:"pk"`
 }


### PR DESCRIPTION
# Description

We already had support for classic fk/pk relations. Table A has a FK pointing to the FID (pk) in Table B.
This PR adds support for composite keys so Table A has columns X,Y pointing to X,Y in Table B.

## Type of change

- Improvement of existing feature

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR